### PR TITLE
Add comments and clean up filtering files.

### DIFF
--- a/code/GaussianSIR.R
+++ b/code/GaussianSIR.R
@@ -6,7 +6,7 @@ mm0    = 0
 CC20   = 4
 
 ### Nimble Gausian SSM Model Code
-gaussianSSMCode <- nimbleCode({
+gaussianSSM.code <- nimbleCode({
   theta.t[1] ~ dnorm(mm0, sd = sqrt(CC20))
   for(i in 1:TT){
     theta.t[i+1] ~ dnorm(theta.t[i], sd = sqrt(tau2))
@@ -27,7 +27,7 @@ for(i in 1:TT){
 }
 
 ### Creating Nimble Gausian SSM 
-gaussianSSM <- nimbleModel(code = gaussianSSMCode, data = list(y = y), 
+gaussianSSM <- nimbleModel(code = gaussianSSM.code, data = list(y = y), 
                            constants = list(sigma2 = sigma2, tau2 = tau2,
                                             mm0 = mm0, CC20 = CC20, TT = 150),
                            dimensions = list(theta.t = 151, y = 150))
@@ -35,19 +35,29 @@ CgaussianSSM <- compileNimble(gaussianSSM)
 
 ### Creating Filter.
 ## "thresh = 1" option ensures that resampling will happen at each time point.
-gaussianSSM_SIRfilter <- buildBootstrapFilter(gaussianSSM, nodes = 'theta.t',
+gaussianSSM.SIRfilter <- buildBootstrapFilter(gaussianSSM, nodes = 'theta.t',
                                  control = list(thresh = 1, saveAll = TRUE))
-CgaussianSSM_SIRfilter <- compileNimble(gaussianSSM_SIRfilter,
+CgaussianSSM.SIRfilter <- compileNimble(gaussianSSM.SIRfilter,
                                         project = gaussianSSM)
 BB = 10000
-CgaussianSSM_SIRfilter$run(BB)
-weights.out <- exp(as.matrix(CgaussianSSM_SIRfilter$mvWSamples)[, 152:302]) /
-    apply(exp(as.matrix(CgaussianSSM_SIRfilter$mvWSamples)[, 152:302]), 2, sum)
-particleSamples <- as.matrix(CgaussianSSM_SIRfilter$mvWSamples)[, 1:151]
-mm.SIR <- apply(weights.out*particleSamples, 2, sum)
-CC2.SIR <- apply(weights.out*particleSamples^2, 2, sum) - mm.SIR^2
-ESS <- CgaussianSSM_SIRfilter$returnESS()
+CgaussianSSM.SIRfilter$run(BB)
 
+### The first 151 columns of the output will be particle samples for all
+### 151 time points.
+particle.samples <- as.matrix(CgaussianSSM.SIRfilter$mvWSamples)[, 1:151]
+
+### Columns 152 through 302 of the output will be the unnormalized log 
+### weights for each particle at each time point.
+log.weights.out <- as.matrix(CgaussianSSM.SIRfilter$mvWSamples)[, 152:302]
+### Below, we un-log and normalize the weights
+weights.out <-  exp(log.weights.out)/apply(exp(log.weights.out), 2, sum)
+
+mm.SIR <- apply(weights.out*particle.samples, 2, sum)
+CC2.SIR <- apply(weights.out*particle.samples^2, 2, sum) - mm.SIR^2
+ESS <- CgaussianSSM.SIRfilter$returnESS()
+
+### ESS averaged over all time points. Time point 1 corresponds to the 
+### prior distribution placed on theta in the model, so we drop it
 print(mean(ESS[-1]))
 
 ### Exact solution
@@ -56,7 +66,8 @@ CC2 = rep(0,TT+1)
 mm[1]  = mm0
 CC2[1] = CC20
 for(i in 1:TT){
-  mm[i+1]  = (y[i]/sigma2 + mm[i]/(tau2 + CC2[i]))/(1/sigma2 + 1/(tau2 + CC2[i]))
+  mm[i+1]  = (y[i]/sigma2 + mm[i]/(tau2 + CC2[i]))/(1/sigma2 +
+                                            1/(tau2 + CC2[i]))
   CC2[i+1] = 1/(1/sigma2 + 1/(tau2 + CC2[i]))
 }
 
@@ -67,8 +78,8 @@ plot(theta.t, type="n", xlab="t", ylab=expression(
                    paste("E(",theta[t],"|",y[1:t],")")), lwd=2)
 lines(mm[-1], col="red", lwd=2, lty=2)
 lines(mm.SIR[-1], col="blue", lwd=2, lty=3)
-legend(120,3,c("Exact","SIR"), col=c("red","blue"), lty=c(2,3), lwd=2,
-        bty="n")
+legend(120,3,c("Exact","SIR"), col=c("red","blue"), lty=c(2,3),
+       lwd=2, bty="n")
 dev.off()
 
 
@@ -80,7 +91,8 @@ lines(mm[-1]-2*sqrt(CC2[-1]), col="red", lwd=1, lty=2)
 lines(mm[-1]+2*sqrt(CC2[-1]), col="red", lwd=1, lty=2)
 lines(mm.SIR[-1]-2*sqrt(CC2.SIR[-1]), col="blue", lwd=1, lty=3)
 lines(mm.SIR[-1]+2*sqrt(CC2.SIR[-1]), col="blue", lwd=1, lty=3)
-legend(120,3,c("Exact","SIR"), col=c("red","blue"), lty=c(2,3), lwd=2, bty="n")
+legend(120,3,c("Exact","SIR"), col=c("red","blue"), lty=c(2,3),
+       lwd=2, bty="n")
 dev.off()
 
 
@@ -92,7 +104,9 @@ dev.off()
 
 ## ESS vs logarithm of the variance
 pdf(file.path("plots","Gaussian_ESSvslogVar.pdf"))
-plot(log(apply(weights.out,2,var)[-1]), ESS[-1], ylab="ESS", xlab=expression(paste("log(Var(",omega[t]^{(b)},"))")),ylim=c(0,BB))
+plot(log(apply(weights.out,2,var)[-1]), ESS[-1], ylab="ESS",
+     xlab=expression(paste("log(Var(",omega[t]^{(b)},"))")),
+     ylim=c(0,BB))
 dev.off()
 
 

--- a/code/SVAPF.R
+++ b/code/SVAPF.R
@@ -1,12 +1,22 @@
+library(nimble)
+
 ### Hyperparameters
 eta    = log(0.15/sqrt(252))
 rho    = 0.95
 tau2   = 0.25
 
 
-
+### Nimble Stochastic Volatility Model Code
+sv.Code <- nimbleCode({
+  theta.t[1] ~ dnorm(eta, sd = sqrt(tau2/(1-rho^2)))
+  for(i in 1:TT){
+    theta.t[i+1] ~ dnorm(eta + rho*(theta.t[i] - eta), sd = sqrt(tau2))
+    y[i] ~ dnorm(0, sd = sqrt(exp(2*theta.t[i+1])))
+  }
+})
 
 ### Generating data
+set.seed(1)
 TT     = 150
 theta.t = rep(0, TT+1)
 y       = rep(0, TT)
@@ -17,93 +27,75 @@ for(i in 1:TT){
   y[i] = rnorm(1, 0, exp(theta.t[i+1]))
 }
 
-quartz()
 plot(y, type="l")
 
+### Creating Nimble SV model 
+sv.Model <- nimbleModel(code = sv.Code, data = list(y = y), 
+                           constants = list(eta = eta, rho = rho, 
+                                            tau2 = tau2, TT = 150),
+                           dimensions = list(theta.t = 151, y = 150))
+Csv.Model <- compileNimble(sv.Model)
 
-
-
-
-
-
-
-
-
-
-
-
-### APF filter
+### Creating SIR Filter.  
+### "thresh = 1" option ensures that resampling will happen at each time point.
+sv.Model.SIRfilter <- buildBootstrapFilter(sv.Model, nodes = 'theta.t',
+                                           control = list(thresh = 1, 
+                                                          saveAll = TRUE))
+Csv.Model.SIRfilter <- compileNimble(sv.Model.SIRfilter, project = sv.Model)
 BB = 10000
-theta.out   = array(0, dim=c(TT+1, BB))
-weights.out = array(0, dim=c(TT+1, BB))
-ESS.APF     = rep(0, TT)
-theta.out[1,]     = rnorm(BB, eta, sqrt(tau2/(1-rho^2)))
-weights.out[1,]   = rep(1/BB, BB)
-for(i in 1:TT){
-  mu          = eta + rho*(theta.out[i,] - eta)
-  lvarpi      = log(weights.out[i,]) + dnorm(y[i], 0, exp(mu), log=T)
-  varpi       = exp(lvarpi - max(lvarpi))
-  varpi       = varpi/sum(varpi)
-  ind         = sample(1:BB, BB, replace=TRUE, varpi)
-  theta.tilde = theta.out[i,ind]
-  theta.hat   = rnorm(BB, eta + rho*(theta.tilde - eta), sqrt(tau2))
-  theta.out[i+1,]   = theta.hat
-  
-  lweights    = dnorm(y[i], 0, exp(theta.hat), log=T) - dnorm(y[i], 0, exp(mu[ind]), log=T)
-  lweights    = lweights - max(lweights)
-  weights.out[i+1,] = exp(lweights)/sum(exp(lweights))
-  ESS.APF[i]        = (sum(weights.out[i+1,])^2)/sum(weights.out[i+1,]^2)
-}
-mm.APF = apply(weights.out*theta.out, 1,sum)
-CC2.APF = apply(weights.out*theta.out^2, 1,sum) - mm.APF^2
+Csv.Model.SIRfilter$run(BB)
 
+### The first 151 columns of the output will be particle samples 
+### for all 151 time points.
+particle.samples <- as.matrix(Csv.Model.SIRfilter$mvWSamples)[, 1:151]
 
+### Columns 152 through 302 of the output will be the unnormalized log weights
+### for each particle at each time point.
+log.weights.out <- as.matrix(Csv.Model.SIRfilter$mvWSamples)[, 152:302]
+### Below, we un-log and normalize the weights
+weights.out <-  exp(log.weights.out)/apply(exp(log.weights.out), 2, sum)
 
-### SIR filter
+mm.SIR <- apply(weights.out*particle.samples, 2, sum)
+CC2.SIR <- apply(weights.out*particle.samples^2, 2, sum) - mm.SIR^2
+ESS.SIR <- Csv.Model.SIRfilter$returnESS()
+
+### ESS averaged over all time points. Time point 1 corresponds to the 
+### prior distribution placed on theta in the model, so we drop it
+print(mean(ESS.SIR[-1]))
+
+### Creating APF Filter.  
+svModel.APfilter <- buildAuxiliaryFilter(sv.Model, nodes = 'theta.t',
+                                         control = list(lookahead = 'mean',
+                                                        saveAll = TRUE))
+CsvModel.APfilter <- compileNimble(svModel.APfilter, project = sv.Model,
+                                   resetFunctions = TRUE)
 BB = 10000
-theta.out   = array(0, dim=c(TT+1, BB))
-weights.out = array(0, dim=c(TT+1, BB))
-ESS.SIR     = rep(0, TT)
-theta.out[1,]     = rnorm(BB, eta, sqrt(tau2/(1-rho^2)))
-weights.out[1,]   = rep(1/BB, BB)
-for(i in 1:TT){
-  varpi       = weights.out[i,]
-  ind         = sample(1:BB, BB, replace=TRUE, varpi)
-  theta.tilde = theta.out[i,ind]
-  theta.hat   = rnorm(BB, eta + rho*(theta.tilde - eta), sqrt(tau2))
-  lweights    = dnorm(y[i], 0, exp(theta.hat), log=T)
-  lweights    = lweights - max(lweights)
-  
-  theta.out[i+1,]   = theta.hat
-  weights.out[i+1,] = exp(lweights)/sum(exp(lweights))
-  ESS.SIR[i]        = (sum(weights.out[i+1,])^2)/sum(weights.out[i+1,]^2)
-}
-mm.SIR = apply(weights.out*theta.out, 1,sum)
-CC2.SIR = apply(weights.out*theta.out^2, 1,sum) - mm.SIR^2
+CsvModel.APfilter$run(BB)
+particle.samples <- as.matrix(CsvModel.APfilter$mvWSamples)[, 1:151]
+log.weights.out <- as.matrix(CsvModel.APfilter$mvWSamples)[, 152:302]
+weights.out <-  exp(log.weights.out)/apply(exp(log.weights.out), 2, sum)
 
+mm.APF <- apply(weights.out*particle.samples, 2, sum)
+CC2.APF <- apply(weights.out*particle.samples^2, 2, sum) - mm.APF^2
+ESS.APF <- CsvModel.APfilter$returnESS()
 
-
-
-
+print(mean(ESS.APF[-1]))
 
 ## Expected values
-quartz()
-plot(theta.t, type="l", xlab="t", ylab=expression(paste("E(",theta[t],"|",y[1:t],")")), lwd=2)
+plot(theta.t, type="l", xlab="t", 
+     ylab=expression(paste("E(",theta[t],"|",y[1:t],")")), lwd=2)
 lines(mm.SIR[-1], col="blue", lwd=2, lty=3)
 lines(mm.APF[-1], col="green", lwd=2, lty=4)
-legend(120,4,c("True","SIR","APF"), col=c("black","blue","green"), lty=c(1,3,4), lwd=2, bty="n")
-#dev.print(dev=pdf,file="Gaussian_means_APF.pdf")
+legend(120,-2,c("True","SIR","APF"), col=c("black","blue","green"),
+       lty=c(1,3,4), lwd=2, bty="n")
 
 
 ## ESS as a function of time
-quartz()
 plot(ESS.SIR, type="l", ylab="ESS", xlab="t", ylim=c(0,BB), lty=3, col="blue")
 lines(ESS.APF,lty=4, col="green")
-legend(120,9000,c("SIR","APF"), col=c("blue","green"), lty=c(3,4), lwd=2, bty="n")
-#dev.print(dev=pdf,file="Gaussian_ESSintime_APF.pdf")
+legend(120,10000,c("SIR","APF"), col=c("blue","green"), lty=c(3,4),
+       lwd=2, bty="n")
 
-mean(ESS.SIR)
-mean(ESS.APF)
 
 
 


### PR DESCRIPTION
@paciorek I've added some lines of comments that describe why we want to drop the first column when creating the graphs, and why e.g.  columns 1:151 are of interest.  I've also standardized the naming of the objects a bit to more closely mirror the original file.  Also, I seem to have accidentally  un-NIMBLEized the `SVAPF.R` file in my previous commit, so that is fixed here.